### PR TITLE
APIS-5088: Update context validation rules

### DIFF
--- a/app/uk/gov/hmrc/apidefinition/validators/ApiContextValidator.scala
+++ b/app/uk/gov/hmrc/apidefinition/validators/ApiContextValidator.scala
@@ -36,7 +36,8 @@ class ApiContextValidator @Inject()(apiDefinitionService: APIDefinitionService,
                                    (implicit override val ec: ExecutionContext) extends Validator[String] {
 
 
-  private val ValidTopLevelContexts: Set[String] = Set("agents", "customs", "individuals", "mobile", "obligations", "organisations", "test", "payments", "misc", "accounts")
+  private val ValidTopLevelContexts: Set[String] =
+    Set("agents", "customs", "individuals", "mobile", "obligations", "organisations", "test", "payments", "misc", "accounts")
   private val contextRegex: Regex = """^[a-zA-Z0-9_\-\/]+$""".r
 
   def validate(errorContext: String, apiDefinition: APIDefinition)(implicit context: String): Future[HMRCValidated[String]] = {
@@ -64,7 +65,6 @@ class ApiContextValidator @Inject()(apiDefinitionService: APIDefinitionService,
       contextNotChangedValidated <- validateContextNotChanged(errorContext, apiDefinition)
       newAPITopLevelContextValidated <- existingAPIDefinitionFuture.flatMap(existingAPIDefinition => existingAPIDefinition match {
         case None => validationsForNewAPI(errorContext)
-        case Some(found: APIDefinition) if(found.versions.size < apiDefinition.versions.size)  => validationsForNewAPI(errorContext)
         case Some(_) => successful(context.validNel)
       })
     } yield (contextUniqueValidated, contextNotChangedValidated, newAPITopLevelContextValidated).mapN((_, _, _) => context)

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,9 @@ lazy val appDependencies: Seq[ModuleID] = compile ++ test ++ tmpMacWorkaround
 
 lazy val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-play-26" % "1.13.0",
+  "uk.gov.hmrc" %% "bootstrap-play-26" % "2.1.0",
   "uk.gov.hmrc" %% "simple-reactivemongo" % "7.30.0-play-26",
-  "uk.gov.hmrc" %% "play-json-union-formatter" % "1.11.0",
+  "uk.gov.hmrc" %% "play-json-union-formatter" % "1.12.0-play-26",
   "org.typelevel" %% "cats-core" % "1.1.0",
   "uk.gov.hmrc" %% "raml-tools" % "1.18.0",
   "org.raml" % "raml-parser-2" % "1.0.13",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,10 @@ resolvers += "hmrc-releases" at "https://artefacts.tax.service.gov.uk/artifactor
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.8.0")


### PR DESCRIPTION
Allow new versions of existing APIs to be published even if their contexts do not conform to naming rules